### PR TITLE
Make some other rules warnings

### DIFF
--- a/crates/unsoundness_checker/src/rules.rs
+++ b/crates/unsoundness_checker/src/rules.rs
@@ -33,7 +33,7 @@ declare_rule! {
     pub (crate) static TYPING_ANY_USED = {
         summary: "detects usage of `typing.Any` in type annotations",
         status: RuleStatus::stable("1.0.0"),
-        default_level: Level::Error,
+        default_level: Level::Warn,
     }
 }
 
@@ -86,7 +86,7 @@ declare_rule! {
     pub (crate) static TYPING_OVERLOAD_USED = {
         summary: "detects usage of overloaded functions",
         status: RuleStatus::stable("1.0.0"),
-        default_level: Level::Error,
+        default_level: Level::Warn,
     }
 }
 

--- a/crates/unsoundness_checker/tests/rule_configuration_test.rs
+++ b/crates/unsoundness_checker/tests/rule_configuration_test.rs
@@ -106,7 +106,7 @@ def foo(x: int | str) -> int | str:
 
     let output = runner.run_test();
     insta::assert_snapshot!(output, @r#"
-    error[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
+    warning[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
      --> test.py:4:1
       |
     2 | from typing import overload
@@ -117,7 +117,7 @@ def foo(x: int | str) -> int | str:
       |
     info: rule `typing-overload-used` is enabled by default
 
-    error[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
+    warning[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
      --> test.py:7:1
       |
     5 | def foo(x: int) -> str: ...
@@ -170,7 +170,7 @@ def foo(x: int | str) -> int | str:
 
     let output = runner.run_test();
     insta::assert_snapshot!(output, @r"
-    error[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
+    warning[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
      --> test.py:4:1
       |
     2 | from typing import overload
@@ -181,7 +181,7 @@ def foo(x: int | str) -> int | str:
       |
     info: rule `typing-overload-used` is enabled by default
 
-    error[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
+    warning[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
      --> test.py:7:1
       |
     5 | def foo(x: int) -> str: ...
@@ -250,7 +250,7 @@ def overload_func(x: int | str) -> int | str:
       |
     info: rule `typing-any-used` was selected in the configuration file
 
-    error[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
+    warning[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
      --> test.py:7:1
       |
     5 |     return x + 1
@@ -261,7 +261,7 @@ def overload_func(x: int | str) -> int | str:
       |
     info: rule `typing-overload-used` is enabled by default
 
-    error[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
+    warning[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
       --> test.py:10:1
        |
      8 | def overload_func(x: int) -> str: ...
@@ -318,7 +318,7 @@ def overload_func(x: int | str) -> int | str:
 
     let output = runner.run_test();
     insta::assert_snapshot!(output, @r"
-    error[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
+    warning[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
      --> test.py:7:1
       |
     5 |     return x + 1
@@ -329,7 +329,7 @@ def overload_func(x: int | str) -> int | str:
       |
     info: rule `typing-overload-used` is enabled by default
 
-    error[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
+    warning[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
       --> test.py:10:1
        |
      8 | def overload_func(x: int) -> str: ...
@@ -398,7 +398,7 @@ def overload_func(x: int | str) -> int | str:
       |
     info: rule `typing-any-used` was selected in the configuration file
 
-    error[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
+    warning[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
      --> test.py:7:1
       |
     5 |     return x + 1
@@ -409,7 +409,7 @@ def overload_func(x: int | str) -> int | str:
       |
     info: rule `typing-overload-used` is enabled by default
 
-    error[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
+    warning[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
       --> test.py:10:1
        |
      8 | def overload_func(x: int) -> str: ...
@@ -495,7 +495,7 @@ def overload_func(x: int | str) -> int | str:
 
     let output = runner.run_test();
     insta::assert_snapshot!(output, @r"
-    error[typing-any-used]: Using `typing.Any` in type annotations can lead to runtime errors.
+    warning[typing-any-used]: Using `typing.Any` in type annotations can lead to runtime errors.
      --> test.py:4:17
       |
     2 | from typing import Any, overload
@@ -506,7 +506,7 @@ def overload_func(x: int | str) -> int | str:
       |
     info: rule `typing-any-used` is enabled by default
 
-    error[typing-any-used]: Using `typing.Any` in type annotations can lead to runtime errors.
+    warning[typing-any-used]: Using `typing.Any` in type annotations can lead to runtime errors.
      --> test.py:4:25
       |
     2 | from typing import Any, overload
@@ -517,7 +517,7 @@ def overload_func(x: int | str) -> int | str:
       |
     info: rule `typing-any-used` is enabled by default
 
-    error[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
+    warning[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
      --> test.py:7:1
       |
     5 |     return x + 1
@@ -528,7 +528,7 @@ def overload_func(x: int | str) -> int | str:
       |
     info: rule `typing-overload-used` is enabled by default
 
-    error[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
+    warning[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
       --> test.py:10:1
        |
      8 | def overload_func(x: int) -> str: ...
@@ -619,7 +619,7 @@ def foo(x: int | str) -> int | str:
 
     let output = runner.run_test();
     insta::assert_snapshot!(output, @r"
-    error[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
+    warning[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
      --> test.py:4:1
       |
     2 | from typing import overload
@@ -630,7 +630,7 @@ def foo(x: int | str) -> int | str:
       |
     info: rule `typing-overload-used` is enabled by default
 
-    error[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
+    warning[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
      --> test.py:7:1
       |
     5 | def foo(x: int) -> str: ...
@@ -721,7 +721,7 @@ def foo(x: int | str) -> int | str:
 
     let output = runner.run_test();
     insta::assert_snapshot!(output, @r"
-    error[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
+    warning[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
      --> test.py:4:1
       |
     2 | from typing import overload
@@ -732,7 +732,7 @@ def foo(x: int | str) -> int | str:
       |
     info: rule `typing-overload-used` is enabled by default
 
-    error[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
+    warning[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
      --> test.py:7:1
       |
     5 | def foo(x: int) -> str: ...
@@ -801,7 +801,7 @@ def overload_func(x: int | str) -> int | str:
       |
     info: rule `typing-any-used` was selected in the configuration file
 
-    error[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
+    warning[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
      --> test.py:7:1
       |
     5 |     return x + 1
@@ -812,7 +812,7 @@ def overload_func(x: int | str) -> int | str:
       |
     info: rule `typing-overload-used` is enabled by default
 
-    error[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
+    warning[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
       --> test.py:10:1
        |
      8 | def overload_func(x: int) -> str: ...
@@ -891,7 +891,7 @@ def overload_func(x: int | str) -> int | str:
       |
     info: rule `typing-any-used` was selected in the configuration file
 
-    error[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
+    warning[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
      --> test.py:7:1
       |
     5 |     return x + 1
@@ -902,7 +902,7 @@ def overload_func(x: int | str) -> int | str:
       |
     info: rule `typing-overload-used` is enabled by default
 
-    error[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
+    warning[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
       --> test.py:10:1
        |
      8 | def overload_func(x: int) -> str: ...
@@ -992,7 +992,7 @@ def overload_func(x: int | str) -> int | str:
       |
     info: rule `typing-any-used` was selected in the configuration file
 
-    error[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
+    warning[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
      --> test.py:7:1
       |
     5 |     return x + 1
@@ -1003,7 +1003,7 @@ def overload_func(x: int | str) -> int | str:
       |
     info: rule `typing-overload-used` is enabled by default
 
-    error[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
+    warning[typing-overload-used]: Using `typing.overload` can lead to runtime errors.
       --> test.py:10:1
        |
      8 | def overload_func(x: int) -> str: ...

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -31,10 +31,36 @@ foo("1")
 
 [See more](rules/invalid_overload_implementation.md)
 
+## `type-checking-directive-used`
+
+<small>
+Default level: `warn`.
+</small>
+
+**What it does**
+
+Checks for usage of type checking directives in comments.
+
+**Why is this bad?**
+
+Type checking directives like `# type: ignore` suppress type checker warnings,
+which can hide potential type errors that may lead to runtime failures.
+These directives bypass the safety guarantees that type checking provides.
+
+**Examples**
+
+```python
+# mypy / standard (PEP 484)
+x = "string" + 123  # type: ignore
+y = foo()  # type: ignore[attr-defined]
+```
+
+[See more](rules/type_checking_directive_used.md)
+
 ## `typing-any-used`
 
 <small>
-Default level: `error`.
+Default level: `warn`.
 </small>
 
 **What it does**
@@ -61,7 +87,7 @@ foo("1")
 ## `typing-overload-used`
 
 <small>
-Default level: `error`.
+Default level: `warn`.
 </small>
 
 **What it does**
@@ -87,30 +113,4 @@ def foo(x: int | str) -> int | str:
 ```
 
 [See more](rules/typing_overload_used.md)
-
-## `type-checking-directive-used`
-
-<small>
-Default level: `warn`.
-</small>
-
-**What it does**
-
-Checks for usage of type checking directives in comments.
-
-**Why is this bad?**
-
-Type checking directives like `# type: ignore` suppress type checker warnings,
-which can hide potential type errors that may lead to runtime failures.
-These directives bypass the safety guarantees that type checking provides.
-
-**Examples**
-
-```python
-# mypy / standard (PEP 484)
-x = "string" + 123  # type: ignore
-y = foo()  # type: ignore[attr-defined]
-```
-
-[See more](rules/type_checking_directive_used.md)
 


### PR DESCRIPTION
## Summary

Since some of our rules only detect possible unsoundness, it seems appropriate to make them warnings instead of errors